### PR TITLE
Performance tweak

### DIFF
--- a/plugin/FilterModule/MarkupParser.cs
+++ b/plugin/FilterModule/MarkupParser.cs
@@ -38,8 +38,8 @@ namespace Imazen.SlimResponse
                     HtmlAttribute src = img.Attributes["src"];
                     HtmlAttribute cls = img.Attributes["class"];
 
-                    if ((src != null && src.Value.IndexOf("slimmage=true", StringComparison.InvariantCultureIgnoreCase) > -1)
-                        || (cls != null && cls.Value.IndexOf("slimmage",  StringComparison.InvariantCultureIgnoreCase) > -1))
+                    if ((src != null && src.Value.IndexOf("slimmage=true", StringComparison.OrdinalIgnoreCase) > -1)
+                        || (cls != null && cls.Value.IndexOf("slimmage",  StringComparison.OrdinalIgnoreCase) > -1))
                     {
                         
                         // - append fallback image


### PR DESCRIPTION
When comparing a string for equality where it known to be pure ASCII, it's always preferable to use OrdinalIgnoreCase to InvariantCultureIgnoreCase
